### PR TITLE
🐛 fix: fix exclude exact matched directory not work

### DIFF
--- a/src/watchfs/filters.py
+++ b/src/watchfs/filters.py
@@ -10,7 +10,7 @@ from watchfiles.filters import BaseFilter
 
 def match_pattern(path: Path, pattern: Path) -> bool:
     if pattern.is_dir():
-        return pattern in path.parents
+        return pattern in [path, *path.parents]
     return path.match(str(pattern))
 
 


### PR DESCRIPTION
在 macOS 上使用 `watchfs python:build/python test:build/test --exclude 'python/paddle/_typing/libs/libpaddle/'` 仍然会同步 `python/paddle/_typing/libs/libpaddle/` 的修改，发现这里的 `path.parents` 并不包含其本身