### PR TITLE
✨ feat: support force polling when watch files

### DIFF
--- a/src/watchfs/__main__.py
+++ b/src/watchfs/__main__.py
@@ -20,9 +20,9 @@ from watchfs.rusty import Err, Ok, Result
 if TYPE_CHECKING:
     from watchfiles.filters import BaseFilter
 
-BADGE_ADD = Badge("ADDED", Fore.black, Back.green)
-BADGE_DEL = Badge("DELETED", Fore.black, Back.red)
-BADGE_MOD = Badge("MODIFIED", Fore.black, Back.blue)
+BADGE_ADD = Badge("ADDED", Fore.black, Back.green)  # type: ignore
+BADGE_DEL = Badge("DELETED", Fore.black, Back.red)  # type: ignore
+BADGE_MOD = Badge("MODIFIED", Fore.black, Back.blue)  # type: ignore
 CHANGE_TYPE_TO_BADGE = {
     Change.added: BADGE_ADD,
     Change.deleted: BADGE_DEL,


### PR DESCRIPTION
参考 samuelcolvin/watchfiles#341，添加参数 `--force-polling` 以允许强制轮询，避免部分机器出现 `OSError: OS file watch limit reached.`，虽然确实会消耗一些 CPU（默认 0.3s 轮询一次）[^1]，但总比用不了好（反正在服务器上喵）

[^1]: https://watchfiles.helpmanual.io/api/watch/?h=force_polling#watchfiles.awatch